### PR TITLE
#1 Enable all the jetty HttpConfiguration parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.0]
+### Added
+- *#1 Enable all the jetty HttpConfiguration parameters from ansible* @jmonterrubio
+
+### Fixed
+- *Renamed solrcloud-role in tests playbook* @jmonterrubio
+
 ## [1.0.1]
 ### Fixed
 - *JMX enable* @jmonterrubio

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,8 +26,16 @@ solr_jetty_threads_min: 10
 solr_jetty_threads_max: 10000
 solr_jetty_threads_idle_timeout: 5000
 solr_jetty_threads_stop_timeout: 60000
+
+solr_jetty_secure_port: 8443
 solr_jetty_output_buffer_size: 32768
 solr_jetty_output_aggregation_size: 8192
+solr_jetty_request_header_size: #8192
+solr_jetty_response_header_size: #8192
+solr_jetty_send_server_version: #'false'
+solr_jetty_send_date_header: #'false'
+solr_jetty_header_cache_size: #512
+solr_jetty_delay_dispatch_until_content: #'false'
 
 zookeeper_hosts: localhost:2181
 zookeeper_hosts_solr_path: solr

--- a/templates/jetty.xml.j2
+++ b/templates/jetty.xml.j2
@@ -58,15 +58,15 @@
   <!-- =========================================================== -->
   <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
     <Set name="secureScheme">https</Set>
-    <Set name="securePort"><Property name="solr.jetty.secure.port" default="8443" /></Set>
+    <Set name="securePort"><Property name="solr.jetty.secure.port" default="8443" />{{solr_jetty_secure_port}}</Set>
     <Set name="outputBufferSize"><Property name="solr.jetty.output.buffer.size" default="32768">{{solr_jetty_output_buffer_size}}</Property></Set>
     <Set name="outputAggregationSize"><Property name="solr.jetty.output.aggregation.size" default="8192">{{solr_jetty_output_aggregation_size}}</Property></Set>
-    <Set name="requestHeaderSize"><Property name="solr.jetty.request.header.size" default="8192" /></Set>
-    <Set name="responseHeaderSize"><Property name="solr.jetty.response.header.size" default="8192" /></Set>
-    <Set name="sendServerVersion"><Property name="solr.jetty.send.server.version" default="false" /></Set>
-    <Set name="sendDateHeader"><Property name="solr.jetty.send.date.header" default="false" /></Set>
-    <Set name="headerCacheSize"><Property name="solr.jetty.header.cache.size" default="512" /></Set>
-    <Set name="delayDispatchUntilContent"><Property name="solr.jetty.delayDispatchUntilContent" default="false"/></Set>
+    <Set name="requestHeaderSize"><Property name="solr.jetty.request.header.size" default="8192" />{{solr_jetty_request_header_size}}</Set>
+    <Set name="responseHeaderSize"><Property name="solr.jetty.response.header.size" default="8192" />{{solr_jetty_response_header_size}}</Set>
+    <Set name="sendServerVersion"><Property name="solr.jetty.send.server.version" default="false" />{{solr_jetty_send_server_version}}</Set>
+    <Set name="sendDateHeader"><Property name="solr.jetty.send.date.header" default="false" />{{solr_jetty_send_date_header}}</Set>
+    <Set name="headerCacheSize"><Property name="solr.jetty.header.cache.size" default="512" />{{solr_jetty_header_cache_size}}</Set>
+    <Set name="delayDispatchUntilContent"><Property name="solr.jetty.delayDispatchUntilContent" default="false"/>{{solr_jetty_delay_dispatch_until_content}}</Set>
     <!-- Uncomment to enable handling of X-Forwarded- style headers
     <Call name="addCustomizer">
       <Arg><New class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/></Arg>

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -4,4 +4,4 @@
   roles:
     - role: java
     - role: zookeeper
-    - role: solr-cloud-role
+    - role: solrcloud-role


### PR DESCRIPTION
Enable all the jetty HttpConfiguration parameters from ansible
Renamed solrcloud-role in tests playbook